### PR TITLE
Add update-deps script

### DIFF
--- a/node-scripts/jsconfig.json
+++ b/node-scripts/jsconfig.json
@@ -5,22 +5,11 @@
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
     /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
-    "target": "ES2015",
+    // Note: Use ES2018 for Node.js v10
+    "target": "ES2018",
     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     "module": "commonjs",
-    /* Specify library files to be included in the compilation. */
-    "lib": [
-      "ES5",
-      "es2015.collection",
-      "es2015.core",
-      "es2015.generator",
-      "es2015.iterable",
-      "es2015.symbol",
-      "es2015.symbol.wellknown",
-      "es2016.array.include",
-      "es2017.string",
-      "es2019.string"
-    ],
+    // "lib": [],                             /* Specify library files to be included in the compilation. */
     /* Report errors in .js files. */
     "checkJs": true,
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
@@ -62,9 +51,7 @@
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
-    /* Type declaration files to be included in compilation. */
-    // (Disallow @types/node in JS scripts inside release/*)
-    "types": [],
+    // "types": [],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     "esModuleInterop": true,
@@ -86,6 +73,5 @@
     "skipLibCheck": true,
     /* Disallow inconsistently-cased references to the same file. */
     "forceConsistentCasingInFileNames": true
-  },
-  "exclude": ["node-scripts"]
+  }
 }

--- a/node-scripts/update-deps.js
+++ b/node-scripts/update-deps.js
@@ -1,0 +1,24 @@
+/**
+ * @file Update NPM dependencies that are committed into this repository.
+ */
+
+const { copyFileSync } = require("fs");
+
+const FILES_TO_COPY = {
+  "node_modules/tablesort/dist/sorts/tablesort.number.min.js":
+    "release/relay/100familiars/tablesort.number.min.js",
+  "node_modules/tablesort/dist/tablesort.min.js":
+    "release/relay/100familiars/tablesort.min.js",
+  "node_modules/tablesort/tablesort.css":
+    "release/relay/100familiars/tablesort.css",
+};
+
+try {
+  for (const [source, dest] of Object.entries(FILES_TO_COPY)) {
+    console.log(`Copying ${source} -> ${dest}`);
+    copyFileSync(source, dest);
+  }
+} catch (e) {
+  console.error(e);
+  process.exitCode = 1;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,11 @@
       "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
       "dev": true
     },
+    "tablesort": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/tablesort/-/tablesort-5.2.1.tgz",
+      "integrity": "sha512-AmNSrtzyba5Bd+Fm8oJJj/xS2bj5acoHEsDHxER2/4Tzo+5noPORpEsSLT9dI15X2MIuXlNnj+BBQcpMsoeTXQ=="
+    },
     "typescript": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,12 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/node": {
+      "version": "10.17.48",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.48.tgz",
+      "integrity": "sha512-Agl6xbYP6FOMDeAsr3QVZ+g7Yzg0uhPHWx0j5g4LFdUBHVtqtU+gH660k/lCEe506jJLOGbEzsnqPDTZGJQLag==",
+      "dev": true
+    },
     "kolmafia": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/kolmafia/-/kolmafia-1.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "tablesort": "^5.2.1"
   },
   "devDependencies": {
+    "@types/node": "^10.17.48",
     "kolmafia": "^1.0.3",
     "prettier": "^2.2.1",
     "typescript": "^4.1.2"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "postinstall": "npm run update-deps && prettier --write .",
-    "test": "tsc -p jsconfig.json && prettier --check .",
+    "test": "tsc -p jsconfig.json && tsc -p node-scripts/jsconfig.json && prettier --check .",
     "update-deps": "node node-scripts/update-deps.js"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.1.0-alpha",
   "description": "Relay script for KoLmafia that displays owned familiars and their 100% runs\"",
   "main": "release/relay/relay_100familiars.js",
-  "dependencies": {},
+  "dependencies": {
+    "tablesort": "^5.2.1"
+  },
   "devDependencies": {
     "kolmafia": "^1.0.3",
     "prettier": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0-alpha",
   "description": "Relay script for KoLmafia that displays owned familiars and their 100% runs\"",
   "main": "release/relay/relay_100familiars.js",
+  "engines": {
+    "node": ">=10"
+  },
   "dependencies": {
     "tablesort": "^5.2.1"
   },
@@ -13,7 +16,9 @@
     "typescript": "^4.1.2"
   },
   "scripts": {
-    "test": "tsc -p jsconfig.json && prettier --check ."
+    "postinstall": "npm run update-deps && prettier --write .",
+    "test": "tsc -p jsconfig.json && prettier --check .",
+    "update-deps": "node node-scripts/update-deps.js"
   },
   "repository": {
     "type": "git",

--- a/release/relay/100familiars/tablesort.css
+++ b/release/relay/100familiars/tablesort.css
@@ -1,33 +1,33 @@
-th[role="columnheader"]:not(.no-sort) {
-  cursor: pointer;
+th[role=columnheader]:not(.no-sort) {
+	cursor: pointer;
 }
 
-th[role="columnheader"]:not(.no-sort):after {
-  content: "";
-  float: right;
-  margin-top: 7px;
-  border-width: 0 4px 4px;
-  border-style: solid;
-  border-color: #404040 transparent;
-  visibility: hidden;
-  opacity: 0;
-  -ms-user-select: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  user-select: none;
+th[role=columnheader]:not(.no-sort):after {
+	content: '';
+	float: right;
+	margin-top: 7px;
+	border-width: 0 4px 4px;
+	border-style: solid;
+	border-color: #404040 transparent;
+	visibility: hidden;
+	opacity: 0;
+	-ms-user-select: none;
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	user-select: none;
 }
 
-th[aria-sort="ascending"]:not(.no-sort):after {
-  border-bottom: none;
-  border-width: 4px 4px 0;
+th[aria-sort=ascending]:not(.no-sort):after {
+	border-bottom: none;
+	border-width: 4px 4px 0;
 }
 
 th[aria-sort]:not(.no-sort):after {
-  visibility: visible;
-  opacity: 0.4;
+	visibility: visible;
+	opacity: 0.4;
 }
 
-th[role="columnheader"]:not(.no-sort):hover:after {
-  visibility: visible;
-  opacity: 1;
+th[role=columnheader]:not(.no-sort):hover:after {
+	visibility: visible;
+	opacity: 1;
 }


### PR DESCRIPTION
Now that we are using NPM, install [tablesort](https://github.com/tristen/tablesort) as our dependency.

- Also add `update-deps.js`, which updates the minified `tablesort` files when we run `npm install` on our own project.
- Also define minimum Node.js version (>= 10) for `update-deps.js`