### PR TITLE
Integrate Rollup / Use JSX to generate HTML

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,33 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@rollup/plugin-typescript": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-8.0.0.tgz",
+      "integrity": "sha512-2L/kKvM5U4VOm+yVMvPIBF3yMZtQUyopf4YIT+KQbqZBZ8Fsdm7X6yeezy92PMyvvHQG1Pa322MVwxPojQvukA==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.1.0",
+        "resolve": "^1.17.0"
+      }
+    },
+    "@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      }
+    },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
     "@types/node": {
       "version": "10.17.48",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.48.tgz",
@@ -16,6 +43,12 @@
       "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
       "dev": true
     },
+    "estree-walker": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+      "dev": true
+    },
     "fsevents": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
@@ -23,10 +56,46 @@
       "dev": true,
       "optional": true
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "is-core-module": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
     "kolmafia": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/kolmafia/-/kolmafia-1.0.3.tgz",
       "integrity": "sha512-e9H+mhYP/xqhfX56AcbVtc5aIsrWbH2LHNQoG5S2i5k0ST4NaMoIQLxBpkFxPs1rUjHPNDcqxxN1McPviqm/BQ==",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
     },
     "prettier": {
@@ -34,6 +103,16 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
       "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
       "dev": true
+    },
+    "resolve": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+      "dev": true,
+      "requires": {
+        "is-core-module": "^2.1.0",
+        "path-parse": "^1.0.6"
+      }
     },
     "rollup": {
       "version": "2.34.2",
@@ -48,6 +127,12 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/tablesort/-/tablesort-5.2.1.tgz",
       "integrity": "sha512-AmNSrtzyba5Bd+Fm8oJJj/xS2bj5acoHEsDHxER2/4Tzo+5noPORpEsSLT9dI15X2MIuXlNnj+BBQcpMsoeTXQ=="
+    },
+    "tslib": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+      "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
+      "dev": true
     },
     "typescript": {
       "version": "4.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,6 +98,12 @@
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
     },
+    "preact": {
+      "version": "10.5.7",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.5.7.tgz",
+      "integrity": "sha512-4oEpz75t/0UNcwmcsjk+BIcDdk68oao+7kxcpc1hQPNs2Oo3ZL9xFz8UBf350mxk/VEdD41L5b4l2dE3Ug3RYg==",
+      "dev": true
+    },
     "prettier": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,13 @@
       "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
       "dev": true
     },
+    "fsevents": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "dev": true,
+      "optional": true
+    },
     "kolmafia": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/kolmafia/-/kolmafia-1.0.3.tgz",
@@ -27,6 +34,15 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
       "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
       "dev": true
+    },
+    "rollup": {
+      "version": "2.34.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.34.2.tgz",
+      "integrity": "sha512-mvtQLqu3cNeoctS+kZ09iOPxrc1P1/Bt1z15enuQ5feyKOdM3MJAVFjjsygurDpSWn530xB4AlA83TWIzRstXA==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.1.2"
+      }
     },
     "tablesort": {
       "version": "5.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,29 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@rollup/plugin-commonjs": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-17.0.0.tgz",
+      "integrity": "sha512-/omBIJG1nHQc+bgkYDuLpb/V08QyutP9amOrJRUSlYJZP+b/68gM//D8sxJe3Yry2QnYIr3QjR3x4AlxJEN3GA==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.1.0",
+        "commondir": "^1.0.1",
+        "estree-walker": "^2.0.1",
+        "glob": "^7.1.6",
+        "is-reference": "^1.2.1",
+        "magic-string": "^0.25.7",
+        "resolve": "^1.17.0"
+      },
+      "dependencies": {
+        "estree-walker": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+          "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+          "dev": true
+        }
+      }
+    },
     "@rollup/plugin-typescript": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-8.0.0.tgz",
@@ -37,16 +60,50 @@
       "integrity": "sha512-Agl6xbYP6FOMDeAsr3QVZ+g7Yzg0uhPHWx0j5g4LFdUBHVtqtU+gH660k/lCEe506jJLOGbEzsnqPDTZGJQLag==",
       "dev": true
     },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "commander": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
       "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
       "dev": true
     },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
     "estree-walker": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
       "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
     "fsevents": {
@@ -62,6 +119,20 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -70,6 +141,22 @@
       "requires": {
         "function-bind": "^1.1.1"
       }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "is-core-module": {
       "version": "2.2.0",
@@ -80,10 +167,52 @@
         "has": "^1.0.3"
       }
     },
+    "is-reference": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "*"
+      }
+    },
     "kolmafia": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/kolmafia/-/kolmafia-1.0.3.tgz",
       "integrity": "sha512-e9H+mhYP/xqhfX56AcbVtc5aIsrWbH2LHNQoG5S2i5k0ST4NaMoIQLxBpkFxPs1rUjHPNDcqxxN1McPviqm/BQ==",
+      "dev": true
+    },
+    "magic-string": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "dev": true,
+      "requires": {
+        "sourcemap-codec": "^1.4.4"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "path-parse": {
@@ -129,6 +258,12 @@
         "fsevents": "~2.1.2"
       }
     },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
+    },
     "tablesort": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/tablesort/-/tablesort-5.2.1.tgz",
@@ -150,6 +285,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/vhtml/-/vhtml-2.2.0.tgz",
       "integrity": "sha512-TPXrXrxBOslRUVnlVkiAqhoXneiertIg86bdvzionrUYhEuiROvyPZNiiP6GIIJ2Q7oPNVyEtIx8gMAZZE9lCQ=="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -139,6 +139,11 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.2.tgz",
       "integrity": "sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==",
       "dev": true
+    },
+    "vhtml": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/vhtml/-/vhtml-2.2.0.tgz",
+      "integrity": "sha512-TPXrXrxBOslRUVnlVkiAqhoXneiertIg86bdvzionrUYhEuiROvyPZNiiP6GIIJ2Q7oPNVyEtIx8gMAZZE9lCQ=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,11 +10,13 @@
     "tablesort": "^5.2.1"
   },
   "devDependencies": {
+    "@rollup/plugin-typescript": "^8.0.0",
     "@types/node": "^10.17.48",
     "commander": "^6.2.0",
     "kolmafia": "^1.0.3",
     "prettier": "^2.2.1",
     "rollup": "^2.34.2",
+    "tslib": "^2.0.3",
     "typescript": "^4.1.2"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@types/node": "^10.17.48",
     "commander": "^6.2.0",
     "kolmafia": "^1.0.3",
+    "preact": "^10.5.7",
     "prettier": "^2.2.1",
     "rollup": "^2.34.2",
     "tslib": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "100familiars",
   "version": "0.1.0-alpha",
   "description": "Relay script for KoLmafia that displays owned familiars and their 100% runs\"",
-  "main": "release/relay/relay_100familiars.js",
+  "main": "relay/relay_100familiars.js",
   "engines": {
     "node": ">=10"
   },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "typescript": "^4.1.2"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "rollup -c",
     "release": "npm run build && node node-scripts/do-release.js",
     "test": "tsc --noEmit && tsc -p node-scripts/jsconfig.json && prettier --check ."
   },

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "vhtml": "^2.2.0"
   },
   "devDependencies": {
+    "@rollup/plugin-commonjs": "^17.0.0",
     "@rollup/plugin-typescript": "^8.0.0",
     "@types/node": "^10.17.48",
     "commander": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "commander": "^6.2.0",
     "kolmafia": "^1.0.3",
     "prettier": "^2.2.1",
+    "rollup": "^2.34.2",
     "typescript": "^4.1.2"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "node": ">=10"
   },
   "dependencies": {
-    "tablesort": "^5.2.1"
+    "tablesort": "^5.2.1",
+    "vhtml": "^2.2.0"
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^8.0.0",

--- a/relay/modules.d.ts
+++ b/relay/modules.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @file Type definitions for 3rd-party libraries.
+ */
+
+declare module "vhtml" {
+  function h(name: string, attrs?: Record<string, any>): string;
+
+  // Let's borrow JSX types from Preact
+  import { JSX } from "preact";
+  export import JSX = JSX;
+}

--- a/relay/relay_100familiars.tsx
+++ b/relay/relay_100familiars.tsx
@@ -18,6 +18,8 @@ import {
   xpath,
 } from "kolmafia";
 
+import h from "vhtml";
+
 /**
  * Represents an exception thrown when the current KoLmafia version does not
  * match an expected condition.
@@ -120,94 +122,103 @@ function getTerrarium(): Familiar[] {
  * @returns {string} HTML for the familiar table
  */
 function generateFamiliarTable() {
-  let html = `
-<table class="familiars">
-  <thead>
-    <tr>
-      <th class="no-sort" data-sort-method="none"></th>
-      <th>Familiar</th>
-      <th>Owned?</th>
-      <th>Best Run %</th>
-    </tr>
-  </thead>
-  <tbody>`;
-
   const familiarRuns = getFamiliarRuns();
   const terrariumFamiliars = new Set(getTerrarium());
 
-  for (let fam of Familiar.all()) {
-    let bestRunText = "";
-    let runPercentClasses = "col-run-pct";
-    let ownedSymbol;
-    let ownedClasses = "col-owned";
+  return (
+    <table class="familiars">
+      <thead>
+        <tr>
+          <th class="no-sort" data-sort-method="none"></th>
+          <th>Familiar</th>
+          <th>Owned?</th>
+          <th>Best Run %</th>
+        </tr>
+      </thead>
+      <tbody>
+        {Familiar.all().map((fam) => {
+          let bestRunText = "";
+          let runPercentClasses = "col-run-pct";
+          let ownedSymbol;
+          let ownedClasses = "col-owned";
 
-    if (
-      haveFamiliar(fam) ||
-      terrariumFamiliars.has(fam) ||
-      familiarRuns.has(fam)
-    ) {
-      let bestRunRecord = familiarRuns.get(fam);
-      if (bestRunRecord) {
-        let { bestRunPercent } = bestRunRecord;
-        bestRunText = formatString(bestRunPercent, "%.1f");
+          if (
+            haveFamiliar(fam) ||
+            terrariumFamiliars.has(fam) ||
+            familiarRuns.has(fam)
+          ) {
+            let bestRunRecord = familiarRuns.get(fam);
+            if (bestRunRecord) {
+              let { bestRunPercent } = bestRunRecord;
+              bestRunText = formatString(bestRunPercent, "%.1f");
 
-        if (bestRunPercent === 100) {
-          // Perfect run
-          runPercentClasses += " col-run-pct--perfect";
-        } else if (bestRunPercent >= 90 && bestRunPercent < 100) {
-          // Contributes to an Amateur/Professional Tour Guide trophy
-          runPercentClasses += " col-run-pct--tourguide";
-        }
-      }
+              if (bestRunPercent === 100) {
+                // Perfect run
+                runPercentClasses += " col-run-pct--perfect";
+              } else if (bestRunPercent >= 90 && bestRunPercent < 100) {
+                // Contributes to an Amateur/Professional Tour Guide trophy
+                runPercentClasses += " col-run-pct--tourguide";
+              }
+            }
 
-      ownedSymbol = "&#x2714;"; // Checkmark
-      ownedClasses += " col-owned--yes";
-    } else {
-      ownedSymbol = "&#x2718;"; // X mark
-      ownedClasses += " col-owned--no";
-    }
+            ownedSymbol = "&#x2714;"; // Checkmark
+            ownedClasses += " col-owned--yes";
+          } else {
+            ownedSymbol = "&#x2718;"; // X mark
+            ownedClasses += " col-owned--no";
+          }
 
-    html += `
-    <tr>
-      <td class="col-img"><img src="/images/itemimages/${fam.image}"></td>
-      <td>${String(fam)}</td>
-      <td class="${ownedClasses}">${ownedSymbol}</td>
-      <td class="${runPercentClasses}">${bestRunText}</td>
-    </tr>`;
-  }
-
-  html += `
-  </tbody>
-</table>
-`;
-  return html;
+          return (
+            <tr>
+              <td class="col-img">
+                <img src={"/images/itemimages/" + fam.image} />
+              </td>
+              <td>{String(fam)}</td>
+              <td
+                class={ownedClasses}
+                dangerouslySetInnerHTML={{ __html: ownedSymbol }}
+              ></td>
+              <td class={runPercentClasses}>{bestRunText}</td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
 }
 
 /**
  * Entrypoint of the relay script
  */
 export function main() {
-  write(`<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>100familiars</title>
-    <script src="/100familiars/tablesort.min.js"></script>
-    <script src="/100familiars/tablesort.number.min.js"></script>
-    <link rel="stylesheet" href="/100familiars/tablesort.css">
-    <link rel="stylesheet" href="/100familiars/style.css">
-  </head>
-  <body>`);
-
-  write(generateFamiliarTable());
-
-  write(`
-  <script>
-    new Tablesort(document.getElementsByClassName('familiars')[0]);
-  </script>
-  </body>
-</html>`);
+  write(
+    "<!DOCTYPE html>" +
+    (
+      <html lang="en">
+        <head>
+          <meta charSet="UTF-8" />
+          <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1.0"
+          />
+          <title>100familiars</title>
+          <script src="/100familiars/tablesort.min.js"></script>
+          <script src="/100familiars/tablesort.number.min.js"></script>
+          <link rel="stylesheet" href="/100familiars/tablesort.css" />
+          <link rel="stylesheet" href="/100familiars/style.css" />
+        </head>
+        <body>
+          {generateFamiliarTable()}
+          <script
+            dangerouslySetInnerHTML={{
+              __html:
+                "new Tablesort(document.getElementsByClassName('familiars')[0]);",
+            }}
+          ></script>
+        </body>
+      </html>
+    )
+  );
 }
 
 /**

--- a/release.gitignore
+++ b/release.gitignore
@@ -13,3 +13,4 @@
 
 # Exclude TypeScript files
 *.ts
+*.tsx

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,14 +1,15 @@
+import commonjs from "@rollup/plugin-commonjs";
 import typescript from "@rollup/plugin-typescript";
 
 /** @type {import("rollup").RollupOptions} */
 const options = {
-  input: "relay/relay_100familiars.ts",
+  input: "relay/relay_100familiars.tsx",
   output: {
     dir: "relay",
     format: "cjs",
   },
   external: "kolmafia",
-  plugins: [typescript()],
+  plugins: [commonjs(), typescript()],
 };
 
 export default options;

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,14 @@
+import typescript from "@rollup/plugin-typescript";
+
+/** @type {import("rollup").RollupOptions} */
+const options = {
+  input: "relay/relay_100familiars.ts",
+  output: {
+    dir: "relay",
+    format: "cjs",
+  },
+  external: "kolmafia",
+  plugins: [typescript()],
+};
+
+export default options;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "target": "es5",
     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
-    "module": "commonjs",
+    "module": "ES2015",
     /* Specify library files to be included in the compilation. */
     "lib": [
       "ES5",
@@ -57,7 +57,8 @@
     // "noUncheckedIndexedAccess": true,      /* Include 'undefined' in index signature results */
 
     /* Module Resolution Options */
-    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "moduleResolution": "node",
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,9 @@
     ],
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
-    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    "jsx": "react",
+    "jsxFactory": "h",
     // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */


### PR DESCRIPTION
I wanted to use JSX to generate HTML. The type checker and IDE checks tag structure, tag names, attribute names for you.

* Use TypeScript to translate JSX to `h()` calls
* Use [vhtml](https://github.com/developit/vhtml) to convert JSX elements (`h()` calls) to plain HTML strings
* Use [Rollup](https://rollupjs.org/) to bundle vhtml with our project

It took a great deal of trial and error, but here we are!