### PR TITLE
Use dist/ during release process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,6 @@ dist
 
 # Local History for Visual Studio Code
 .history/
+
+# Temporary directory used during release
+/temp/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,2 @@
-# Ignore TypeScript build artifacts
-/relay/*.js
-/scripts/*.js
+# Ignore build artifacts, dependencies, and other release files
+/dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,15 @@
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
     },
+    "@types/fs-extra": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.5.tgz",
+      "integrity": "sha512-wr3t7wIW1c0A2BIJtdVp4EflriVaVVAsCAIHVzzh8B+GiFv9X1xeJjCs4upRXtzp7kQ6lP5xvskjoD4awJ1ZeA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/node": {
       "version": "10.17.48",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.48.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,12 @@
       "integrity": "sha512-Agl6xbYP6FOMDeAsr3QVZ+g7Yzg0uhPHWx0j5g4LFdUBHVtqtU+gH660k/lCEe506jJLOGbEzsnqPDTZGJQLag==",
       "dev": true
     },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -100,6 +106,18 @@
       "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
       "dev": true
     },
+    "fs-extra": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+      "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+      "dev": true,
+      "requires": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^1.0.0"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -132,6 +150,12 @@
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       }
+    },
+    "graceful-fs": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+      "dev": true
     },
     "has": {
       "version": "1.0.3",
@@ -174,6 +198,24 @@
       "dev": true,
       "requires": {
         "@types/estree": "*"
+      }
+    },
+    "jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
+      },
+      "dependencies": {
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+          "dev": true
+        }
       }
     },
     "kolmafia": {
@@ -279,6 +321,12 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.2.tgz",
       "integrity": "sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==",
+      "dev": true
+    },
+    "universalify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
       "dev": true
     },
     "vhtml": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.0.0",
     "@rollup/plugin-typescript": "^8.0.0",
+    "@types/fs-extra": "^9.0.5",
     "@types/node": "^10.17.48",
     "commander": "^6.2.0",
     "fs-extra": "^9.0.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@rollup/plugin-typescript": "^8.0.0",
     "@types/node": "^10.17.48",
     "commander": "^6.2.0",
+    "fs-extra": "^9.0.1",
     "kolmafia": "^1.0.3",
     "preact": "^10.5.7",
     "prettier": "^2.2.1",

--- a/release.gitignore
+++ b/release.gitignore
@@ -10,7 +10,3 @@
 !/relay/
 !/scripts/
 !/dependencies.txt
-
-# Exclude TypeScript files
-*.ts
-*.tsx

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,7 +5,7 @@ import typescript from "@rollup/plugin-typescript";
 const options = {
   input: "relay/relay_100familiars.tsx",
   output: {
-    dir: "relay",
+    dir: "dist/relay",
     format: "cjs",
   },
   external: "kolmafia",


### PR DESCRIPTION
The previous release process, introduced in #4, is tricky to maintain. It creates build artifacts and copies dependencies right next to source files (`.tsx`), and uses an obscure hack to preserve files during a branch switch. It's hard to maintain.

Solve this by creating a separate `dist/` directory where the build artifacts and dependencies go. This directory is added to `.gitignore` so that it survives during the branch switch. Then its contents are copied to the project root, where they can be `git add`-ed.