### PR TITLE
Clean dist/ during release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -300,6 +300,15 @@
         "path-parse": "^1.0.6"
       }
     },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
     "rollup": {
       "version": "2.34.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.34.2.tgz",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "kolmafia": "^1.0.3",
     "preact": "^10.5.7",
     "prettier": "^2.2.1",
+    "rimraf": "^3.0.2",
     "rollup": "^2.34.2",
     "tslib": "^2.0.3",
     "typescript": "^4.1.2"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   },
   "scripts": {
     "build": "rollup -c",
-    "release": "npm run build && node node-scripts/do-release.js",
+    "clean": "rimraf dist",
+    "release": "npm run clean && npm run build && node node-scripts/do-release.js",
     "test": "tsc --noEmit && tsc -p node-scripts/jsconfig.json && prettier --check ."
   },
   "repository": {


### PR DESCRIPTION
Add NPM script: `clean`. This uses [rimraf](https://github.com/isaacs/rimraf). Run this script inside NPM `release` script before running Rollup and copying dependencies.