### PR TITLE
fix: JSX.Element is a string

### DIFF
--- a/relay/modules.d.ts
+++ b/relay/modules.d.ts
@@ -7,5 +7,8 @@ declare module "vhtml" {
 
   // Let's borrow JSX types from Preact
   import { JSX } from "preact";
-  export import JSX = JSX;
+  namespace JSX {
+    export import IntrinsicElements = JSX.IntrinsicElements;
+    export type Element = string;
+  }
 }

--- a/relay/relay_100familiars.tsx
+++ b/relay/relay_100familiars.tsx
@@ -119,9 +119,9 @@ function getTerrarium(): Familiar[] {
 
 /**
  * Generates a sortable HTML table of all familiars.
- * @returns {string} HTML for the familiar table
+ * @returns HTML for the familiar table
  */
-function generateFamiliarTable() {
+function generateFamiliarTable(): string {
   const familiarRuns = getFamiliarRuns();
   const terrariumFamiliars = new Set(getTerrarium());
 
@@ -190,7 +190,7 @@ function generateFamiliarTable() {
 /**
  * Entrypoint of the relay script
  */
-export function main() {
+export function main(): void {
   write(
     "<!DOCTYPE html>" +
     (
@@ -230,7 +230,7 @@ export function main() {
  *    less than `revision`.
  * @throws {TypeError} If `revision` is not an integer
  */
-function sinceKolmafiaRevision(revision: number) {
+function sinceKolmafiaRevision(revision: number): void {
   if (!Number.isInteger(revision)) {
     throw new TypeError(
       `Invalid revision number ${revision} (must be an integer)`


### PR DESCRIPTION
Since vhtml renders JSX to string, define `JSX.Element` as a string instead of pulling in Preact's `JSX.Element`.

(This fixes a TypeScript issue; no effect on the output)