### PR TITLE
build: Release script improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,9 @@ To use another release branch (for testing), use:
 ```
 npm run release -- --branch <branch_name> [commit message]
 ```
+
+To build without committing to a release branch:
+
+```
+npm run release -- --no-
+```

--- a/node-scripts/do-release.js
+++ b/node-scripts/do-release.js
@@ -48,6 +48,8 @@ function updateReleaseBranch(releaseBranch, commitMessage) {
     // Switch to release branch.
     // Since DIST_DIR is .gitignore-ed, it will be preserved after the switch.
     run(`git switch ${releaseBranch}`);
+    // Delete all previously committed files in the release branch
+    run(`git rm -r .`);
     // Copy contents of dist/ into project root (moveSync fails)
     copySync(DIST_DIR, ".");
     // Stage release-worthy files


### PR DESCRIPTION
- Clean the release branch before adding files from `dist/`. This allows the release script to delete files that should no longer be included.
- Add `--no-commit` option to test changes locally before committing