### PR TITLE
test: Type-check Rollup config

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -73,5 +73,6 @@
     "skipLibCheck": true,
     /* Disallow inconsistently-cased references to the same file. */
     "forceConsistentCasingInFileNames": true
-  }
+  },
+  "exclude": ["**/*.ts", "**/*.tsx", "dist"]
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "build": "rollup -c",
     "clean": "rimraf dist",
     "release": "npm run clean && npm run build && node node-scripts/do-release.js",
-    "test": "tsc --noEmit && tsc -p node-scripts/jsconfig.json && prettier --check ."
+    "test": "tsc --noEmit && tsc -p jsconfig.json && prettier --check ."
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Move `node-scripts/jsconfig.json` to `./` (project root dir). Also make it ignore all TypeScript files, and JS files in `dist/`.

Since this config is used to type-check Node.js scripts, it can be used to type-check `rollup.config.js` with minimal hassle.