### PR TITLE
bugfix: Set familiar image size to 30x30

### DIFF
--- a/relay/100familiars/style.css
+++ b/relay/100familiars/style.css
@@ -16,8 +16,8 @@
 }
 
 .col-img > img {
-  height: 32px;
-  width: 32px;
+  height: 30px;
+  width: 30px;
 }
 
 .col-familiar-id,


### PR DESCRIPTION
The vanilla image sizes are 30x30, not 32x32. I wondered why they were looking blurry...