### PR TITLE
Chore: Use @types/vhtml instead of @pastelmind/vhtml-types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,12 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@pastelmind/vhtml-types": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@pastelmind/vhtml-types/-/vhtml-types-0.1.0.tgz",
-      "integrity": "sha512-80zG511L0LaFSzbgLgdOcXbllqcFEaLL8MBN2PYO9Q62JrvDR1wEWxYapWwwHRTor7x/wdy9dMAcyFw/dxglMw==",
-      "dev": true
-    },
     "@rollup/plugin-commonjs": {
       "version": "17.0.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-17.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -122,6 +122,12 @@
       "integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==",
       "dev": true
     },
+    "@types/vhtml": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/vhtml/-/vhtml-2.2.0.tgz",
+      "integrity": "sha512-pZdfQmIZHPqcvGNEr7vquhAw2zAQqXLCqEwekbA1K044SjdHb8NbzEFerN0noB/Teq1ycFlyOIVqsKBnw76X/Q==",
+      "dev": true
+    },
     "at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "vhtml": "^2.2.0"
   },
   "devDependencies": {
-    "@pastelmind/vhtml-types": "^0.1.0",
     "@rollup/plugin-commonjs": "^17.0.0",
     "@rollup/plugin-node-resolve": "^11.0.1",
     "@rollup/plugin-typescript": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@types/datatables.net": "^1.10.19",
     "@types/fs-extra": "^9.0.5",
     "@types/node": "^10.17.49",
+    "@types/vhtml": "^2.2.0",
     "commander": "^6.2.1",
     "fs-extra": "^9.0.1",
     "kolmafia": "^1.0.3",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -63,7 +63,7 @@
     "moduleResolution": "node",
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-    "paths": { "vhtml": ["./node_modules/@pastelmind/vhtml-types"] },
+    // "paths": {},
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     /* Type declaration files to be included in compilation. */


### PR DESCRIPTION
[@types/vhtml](https://www.npmjs.com/package/@types/vhtml) is now public!