### PR TITLE
Prevent accidental NPM publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "100familiars",
   "version": "0.1.0-alpha",
   "description": "Relay script for KoLmafia that displays owned familiars and their 100% runs\"",
+  "private": true,
   "main": "relay/relay_100familiars.js",
   "engines": {
     "node": ">=10"


### PR DESCRIPTION
Since this is intended to be consumed as a KoLmafia package, it should never be published to registry.npmjs.com.