### PR TITLE
build: Use build/dist/ instead of dist/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,5 +113,7 @@ dist
 # Local History for Visual Studio Code
 .history/
 
+# Directory for build artifacts and assets
+/build/
 # Temporary directory used during release
 /temp/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,2 @@
 # Ignore build artifacts, dependencies, and other release files
-/dist
+/build/

--- a/node-scripts/do-release.js
+++ b/node-scripts/do-release.js
@@ -12,7 +12,7 @@ const { copySync } = require("fs-extra");
  * Temporary directory used to store build artifacts and dependencies.
  * This must be .gitignore-ed!
  */
-const DIST_DIR = "dist";
+const DIST_DIR = "build/dist";
 
 /**
  * .gitignore file to filter out everything that does not belong in the release
@@ -56,7 +56,7 @@ function updateReleaseBranch(releaseBranch, commitMessage) {
     run(`git switch ${releaseBranch}`);
     // Delete all previously committed files in the release branch
     run(`git rm -r .`);
-    // Copy contents of dist/ into project root (moveSync fails)
+    // Copy distributables into project root (moveSync fails)
     copySync(DIST_DIR, ".");
     // Stage release-worthy files
     run(`git -c core.excludesFile=${RELEASE_GITIGNORE_TEMP} add .`);

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "scripts": {
     "build": "rollup -c",
-    "clean": "rimraf dist",
+    "clean": "rimraf build",
     "release": "npm run clean && npm run build && node node-scripts/do-release.js",
     "test": "tsc --noEmit && tsc -p tsconfig.browser.json --noEmit && prettier --check ."
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,7 +7,7 @@ import copy from "rollup-plugin-copy";
  * Temporary directory used to store build artifacts and dependencies.
  * This must be .gitignore-ed!
  */
-const DIST_DIR = "dist";
+const DIST_DIR = "build/dist";
 
 /** @type {import("rollup").RollupOptions} */
 const kolmafiaScriptOptions = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -93,5 +93,5 @@
     /* Disallow inconsistently-cased references to the same file. */
     "forceConsistentCasingInFileNames": true
   },
-  "exclude": ["dist", "src/relay/100familiars"]
+  "exclude": ["build", "src/relay/100familiars"]
 }


### PR DESCRIPTION
This allows us to (eventually) place build artifacts generated by `tsc` (e.g. tests and node-scripts) in `build/`, and clean them all using a single command.