### PR TITLE
build: Convert release script to TypeScript

### DIFF
--- a/node-scripts/do-release.ts
+++ b/node-scripts/do-release.ts
@@ -2,11 +2,11 @@
  * @file Commits build artifacts and dependencies to the release branch.
  */
 
-const { execSync } = require("child_process");
+import { execSync } from "child_process";
 
-const chalk = require("chalk");
-const { program } = require("commander");
-const { copySync } = require("fs-extra");
+import chalk from "chalk";
+import { program } from "commander";
+import { copySync } from "fs-extra";
 
 /**
  * Temporary directory used to store build artifacts and dependencies.
@@ -29,21 +29,17 @@ const RELEASE_GITIGNORE_TEMP = "temp/release.gitignore";
  */
 const RELEASE_BRANCH_DEFAULT = "release";
 
-/**
- * @param {string} cmd
- * @param {Parameters<execSync>[1]} [options]
- */
-function run(cmd, options) {
+function run(cmd: string, options?: Parameters<typeof execSync>[1]) {
   console.log(chalk.green("Executing:", cmd));
   execSync(cmd, { stdio: "inherit", ...options });
 }
 
 /**
  * Commit all build artifacts and copied dependencies to the release branch.
- * @param {string} releaseBranch Release branch name
- * @param {string} [commitMessage] Commit message
+ * @param releaseBranch Release branch name
+ * @param commitMessage Commit message
  */
-function updateReleaseBranch(releaseBranch, commitMessage) {
+function updateReleaseBranch(releaseBranch: string, commitMessage?: string) {
   const PREV_POS = execSync("git name-rev --name-only HEAD", {
     encoding: "utf8",
   });
@@ -62,7 +58,7 @@ function updateReleaseBranch(releaseBranch, commitMessage) {
     run(`git -c core.excludesFile=${RELEASE_GITIGNORE_TEMP} add .`);
     // Create a new commit
     run("git commit -F -", {
-      input: commitMessage ? commitMessage : "New release",
+      input: commitMessage ?? "New release",
       stdio: ["pipe", "inherit", "inherit"],
     });
   } finally {
@@ -73,9 +69,8 @@ function updateReleaseBranch(releaseBranch, commitMessage) {
 
 /**
  * Script entrypoint
- * @param {string[]} argv
  */
-function main(argv) {
+function main(argv: string[]) {
   program
     .arguments("[commit_message]")
     .option(

--- a/package.json
+++ b/package.json
@@ -34,8 +34,10 @@
   "scripts": {
     "build": "rollup -c",
     "clean": "rimraf build",
-    "release": "npm run clean && npm run build && node node-scripts/do-release.js",
-    "test": "tsc --noEmit && tsc -p tsconfig.browser.json --noEmit && prettier --check ."
+    "compile": "tsc",
+    "release": "npm run clean && npm run compile && npm run build && node build/node-scripts/do-release.js",
+    "pretest": "npm run compile",
+    "test": "tsc -p tsconfig.browser.json --noEmit && prettier --check ."
   },
   "repository": {
     "type": "git",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -20,7 +20,11 @@ const kolmafiaScriptOptions = {
   // Don't change foreign code so that they operate properly
   context: "this",
   external: "kolmafia",
-  plugins: [nodeResolve(), commonjs(), typescript()],
+  plugins: [
+    nodeResolve(),
+    commonjs(),
+    typescript({ module: "ES2015", outDir: `${DIST_DIR}/relay` }),
+  ],
 };
 
 /** @type {import("rollup").RollupOptions} */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "target": "es5",
     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
-    "module": "ES2015",
+    "module": "CommonJS",
     /* Specify library files to be included in the compilation. */
     "lib": [
       "ES5",
@@ -32,7 +32,8 @@
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    // "outDir": "./",                        /* Redirect output structure to the directory. */
+    /* Redirect output structure to the directory. */
+    "outDir": "build",
     // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                     /* Enable project compilation */
     // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */


### PR DESCRIPTION
- Add NPM `compile` script
  - Run `tsc` without `--noEmit` to compile `do-release.ts`
  - Emit `tsc` artifacts to `/build/`
- Run `npm compile` before `npm test` and `npm release`
- Update Rollup script to play nice with modified `tsconfig.json`