### PR TITLE
fix: Don't set core.excludesFile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,5 +115,3 @@ dist
 
 # Directory for build artifacts and assets
 /build/
-# Temporary directory used during release
-/temp/

--- a/node-scripts/do-release.ts
+++ b/node-scripts/do-release.ts
@@ -17,10 +17,6 @@ const DIST_DIR = "build/dist";
  * branch.
  */
 const RELEASE_GITIGNORE = "release.gitignore";
-/**
- * Where the release.gitignore file will be copied to during the release process
- */
-const RELEASE_GITIGNORE_TEMP = "temp/release.gitignore";
 
 /**
  * Default release branch name
@@ -41,8 +37,9 @@ async function updateReleaseBranch(
   // Retrieve the current branch, tag, or commit name
   const prevPos = (await git.raw("name-rev", "--name-only", "HEAD")).trim();
 
-  // Copy release.gitignore to temp dir so that it survives the branch switch
-  await copy(RELEASE_GITIGNORE, RELEASE_GITIGNORE_TEMP);
+  // Copy .gitignore to dist dir so that it can be copied back to root dir
+  // before committing
+  await copy(RELEASE_GITIGNORE, `${DIST_DIR}/.gitignore`);
 
   try {
     // Switch to release branch.
@@ -68,7 +65,6 @@ async function updateReleaseBranch(
     await copy(DIST_DIR, ".");
 
     // Stage release-worthy files
-    await git.addConfig("core.excludesFile", RELEASE_GITIGNORE_TEMP);
     await git.add(".");
 
     // Create a new commit


### PR DESCRIPTION
I thought `SimpleGit.addConfig()` would _temporarily_ alter the current git config, but it turns out that it _permanently_ modifies the local git config. This is highly undesirable, as a leftover `.gitignore` inside the `build/` dir would affect the entire repository.

Solve this by NOT using `SimpleGit.addConfig()` to apply `release.gitignore`. Instead, copy `release.gitignore` into the `build/dist/` dir AND rename it to `.gitignore`, so that it is also copied back to project root (and therefore apply to the current commit) while updating the release branch.

Note: This bug only applies to the build/release process and does not affect the app itself.