### PR TITLE
fix: Don't emit d.ts files when building

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -29,6 +29,8 @@ const kolmafiaScriptOptions = {
       tsconfig: 'src/tsconfig.json',
       // Disable composite to prevent generating .tsbuildinfo files
       composite: false,
+      // Don't emit d.ts files
+      declaration: false,
       module: 'ES2015',
       outDir: `${DIST_DIR}/relay`,
       // Disable sourcemaps
@@ -49,6 +51,8 @@ const browserScriptOptions = {
       tsconfig: 'src/relay/100familiars/tsconfig.json',
       // Disable composite to prevent generating .tsbuildinfo files
       composite: false,
+      // Don't emit d.ts files
+      declaration: false,
       module: 'ES2015',
       outDir: `${DIST_DIR}/relay/100familiars`,
       // Disable sourcemaps


### PR DESCRIPTION
When I introduced TypeScript build mode in #34 (ccd08bacd2027096ec88fb747ab845282bde0f79), I made all non-solution tsconfigs inherit from the gts tsconfig. The gts tsconfig contains `"declaration": true`, which ensures that `.d.ts` files are emitted.

Since I don't want `.d.ts` files to be added to the release branch, explicitly disable them in the Rollup build config.