### PR TITLE
fix: Use toInt() to get familiar ID

### DIFF
--- a/src/relay/relay_100familiars.tsx
+++ b/src/relay/relay_100familiars.tsx
@@ -12,6 +12,7 @@ import {
   myId,
   print,
   toFamiliar,
+  toInt,
   toString as formatString,
   visitUrl,
   write,
@@ -169,12 +170,12 @@ function FamiliarTable(): string {
               <td class="col-img">
                 <img src={'/images/itemimages/' + fam.image} />
               </td>
-              <td class="col-familiar-id">{Number(fam)}</td>
+              <td class="col-familiar-id">{toInt(fam)}</td>
               <td>{String(fam)}</td>
               <td class="col-links">
                 <a
                   class="popup-link"
-                  href={'/desc_familiar.php?which=' + Number(fam)}
+                  href={'/desc_familiar.php?which=' + toInt(fam)}
                   rel="noreferrer noopener"
                   target="_blank"
                 >


### PR DESCRIPTION
KoLmafia [r20620](https://kolmafia.us/threads/20620-remove-valueof-as-per-philmasterplus.25845/) has removed the ability to retrieve an enumerated type's numeric ID using the `valueOf()` method (or using `Number()`). Because of this, we must use `toInt()` to explicitly retrieve the familiar's ID.