### PR TITLE
ci: Use actions/setup-node-v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci


### PR DESCRIPTION
Use [actions/setup-node](https://github.com/actions/setup-node/) v2, which has been declared stable since [v2.1.4](https://github.com/actions/setup-node/releases/tag/v2.1.4)