### PR TITLE
fix: Put images under `images/relayimages/`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated DataTables to 1.10.24 and jQuery to 3.6.0.
 
+### Fixed
+
+- Moved custom images under `/images/relayimages/` to protect them from being
+  accidentally deleted by the `cache clear` gCLI command. ([#42])
+
+[#42]: https://github.com/pastelmind/100familiars/pull/42
+
 ## [0.1.0] - 2021-02-02
 
 ### Added

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -61,16 +61,17 @@ const browserScriptOptions = {
     copy({
       targets: [
         {
-          // Copy DataTables CSS to /images/100familiars/, because it expects
-          // the images to be in the ../images/ relative path
+          // Copy DataTables CSS to /images/relayimages/100familiars/, because
+          // it expects the images to be in the ../images/ relative path
           src: 'node_modules/datatables.net-dt/css/jquery.Datatables.min.css',
-          dest: `${DIST_DIR}/images/100familiars/css/`,
+          dest: `${DIST_DIR}/images/relayimages/100familiars/css/`,
         },
         {
-          // Copy DataTables images to /images/100familiars/, because KoLmafia
-          // does not serve images inside /relay/
+          // Copy DataTables images to /images/relayimages/100familiars/,
+          // because KoLmafia only serves images under /images/, and
+          // /images/relayimages/ is safe from the `cache clear` gCLI command
           src: 'node_modules/datatables.net-dt/images/*',
-          dest: `${DIST_DIR}/images/100familiars/images/`,
+          dest: `${DIST_DIR}/images/relayimages/100familiars/images/`,
         },
         {
           src: [

--- a/src/relay/relay_100familiars.tsx
+++ b/src/relay/relay_100familiars.tsx
@@ -236,7 +236,7 @@ export function main(): void {
           <script src="/100familiars/100familiars.js"></script>
           <link
             rel="stylesheet"
-            href="/images/100familiars/css/jquery.Datatables.min.css"
+            href="/images/relayimages/100familiars/css/jquery.Datatables.min.css"
           />
           <link rel="stylesheet" href="/100familiars/style.css" />
         </head>


### PR DESCRIPTION
Put images (used by DataTables) and `jquery.Datatables.min.css` (which requires those images to be located relative to itself) under
`images/relayimages`. This prevents the gCLI `clear cache` command from deleting our images and CSS.

Closes #39