### PR TITLE
build: Use ts-node

### DIFF
--- a/node-scripts/do-release.ts
+++ b/node-scripts/do-release.ts
@@ -10,7 +10,7 @@ import simpleGit, {GitError} from 'simple-git';
  * Temporary directory used to store build artifacts and dependencies.
  * This must be .gitignore-ed!
  */
-const DIST_DIR = 'build/dist';
+const DIST_DIR = 'build';
 
 /**
  * .gitignore file to filter out everything that does not belong in the release

--- a/node-scripts/tsconfig.json
+++ b/node-scripts/tsconfig.json
@@ -1,4 +1,0 @@
-// Config for Node.js scripts
-{
-  "extends": "../tsconfig.base.json"
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -518,6 +518,12 @@
         "color-convert": "^2.0.1"
       }
     },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -605,6 +611,12 @@
       "requires": {
         "fill-range": "^7.0.1"
       }
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
     },
     "builtin-modules": {
       "version": "3.2.0",
@@ -772,6 +784,12 @@
         "xdg-basedir": "^4.0.0"
       }
     },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -870,6 +888,12 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
       "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
+      "dev": true
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true
     },
     "dir-glob": {
@@ -1906,6 +1930,12 @@
         }
       }
     },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
     "map-obj": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.2.1.tgz",
@@ -2631,6 +2661,22 @@
         "is-fullwidth-code-point": "^3.0.0"
       }
     },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
     "sourcemap-codec": {
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
@@ -2801,6 +2847,20 @@
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
       "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
       "dev": true
+    },
+    "ts-node": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "dev": true,
+      "requires": {
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      }
     },
     "tslib": {
       "version": "2.2.0",
@@ -3000,6 +3060,12 @@
       "version": "20.2.7",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
       "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
+      "dev": true
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -28,18 +28,16 @@
     "rollup": "^2.46.0",
     "rollup-plugin-copy": "^3.4.0",
     "simple-git": "^2.38.0",
+    "ts-node": "^9.1.1",
     "tslib": "^2.2.0",
     "typescript": "^4.2.4"
   },
   "scripts": {
     "build": "rollup -c",
     "clean": "gts clean",
-    "compile": "tsc -b",
     "fix": "gts fix",
     "lint": "gts lint",
-    "prepare": "npm run compile",
-    "release": "npm run clean && npm run compile && npm run build && node build/node-scripts/do-release.js",
-    "pretest": "npm run compile",
+    "release": "npm run clean && npm run build && ts-node node-scripts/do-release.ts",
     "test": "echo \"No tests to run\"",
     "posttest": "npm run lint"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,7 +9,7 @@ import copy from 'rollup-plugin-copy';
  * Temporary directory used to store build artifacts and dependencies.
  * This must be .gitignore-ed!
  */
-const DIST_DIR = 'build/dist';
+const DIST_DIR = 'build';
 
 /** @type {import("rollup").RollupOptions} */
 const kolmafiaScriptOptions = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,9 @@
-// Master config that executes all other configs
+// "Solution" tsconfig for code that runs in Node.js (scripts)
 {
   "compilerOptions": {
+    "noEmit": true,
     // Needed for `gts clean`, nothing else
     "outDir": "build"
   },
-  "files": [],
-  "references": [
-    {"path": "node-scripts"},
-    {"path": "src"},
-    {"path": "src/relay/100familiars"}
-  ]
+  "exclude": ["src"]
 }


### PR DESCRIPTION
[ts-node](https://github.com/TypeStrong/ts-node) can compile and run TypeScript scripts on the fly, obviating the need for a separate compile step. This allows us to devote the `build/` directory entirely for staging release bundles.

This PR also deletes extraneous `tsconfig.json` files and simplifies the root (solution) tsconfig. TypeScript's build mode may have its uses, but this small project is not one of them.